### PR TITLE
Update Minecraft server status query to latest upstream version for 1.9

### DIFF
--- a/Packets/HandshakePacket.php
+++ b/Packets/HandshakePacket.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Minecraft Server Status Query
+ *
+ * @link        https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/
+ * @author      Julian Spravil <julian.spr@t-online.de>
+ * @copyright   Copyright (c) 2016 Julian Spravil
+ * @license     https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/blob/master/LICENSE
+ */
+namespace MinecraftServerStatus\Packets;
+
+class HandshakePacket extends Packet {
+
+    public function __construct ($host, $port, $protocol, $nextState) {
+        parent::__construct(0);
+        $this->addUnsignedChar($protocol);
+        $this->addString($host);
+        $this->addUnsignedShort($port);
+        $this->addUnsignedChar($nextState);
+    }
+}

--- a/Packets/Packet.php
+++ b/Packets/Packet.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Minecraft Server Status Query
+ *
+ * @link        https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/
+ * @author      Julian Spravil <julian.spr@t-online.de>
+ * @copyright   Copyright (c) 2016 Julian Spravil
+ * @license     https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/blob/master/LICENSE
+ */
+namespace MinecraftServerStatus\Packets;
+
+class Packet {
+
+    protected $packetID;
+
+    protected $data;
+
+    public function __construct ($packetID) {
+        $this->packetID = $packetID;
+        $this->data = pack('C', $packetID);
+    }
+
+    public function addSignedChar ($data) {
+        $this->data .= pack('c', $data);
+    }
+
+    public function addUnsignedChar ($data) {
+        $this->data .= pack('C', $data);
+    }
+
+    public function addSignedShort ($data) {
+        $this->data .= pack('s', $data);
+    }
+
+    public function addUnsignedShort ($data) {
+        $this->data .= pack('S', $data);
+    }
+
+    public function addString ($data) {
+        $this->data .= pack('C', strlen($data));
+        $this->data .= $data;
+    }
+
+    public function send ($socket) {
+        $this->data = pack('C', strlen($this->data)) . $this->data;
+        socket_send($socket, $this->data, strlen($this->data), 0);
+    }
+}

--- a/Packets/PingPacket.php
+++ b/Packets/PingPacket.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Minecraft Server Status Query
+ *
+ * @link        https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/
+ * @author      Julian Spravil <julian.spr@t-online.de>
+ * @copyright   Copyright (c) 2016 Julian Spravil
+ * @license     https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/blob/master/LICENSE
+ */
+namespace MinecraftServerStatus\Packets;
+
+class PingPacket extends Packet {
+
+    public function __construct () {
+        parent::__construct(0);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Website repository for the RIT Minecraft server.
 ## What is it?
 This repository is for the RIT Minecraft server (also known as "RITcraft") website. RITcraft was started in October 2015 and is open to all students at the Rochester Institute of Technology.
 
-* **IP**: *rit.j-f.co*
-* **Website**: *[rit.j-f.co](http://rit.j-f.co)*
+* **Minecraft IP**: *mc.ritcraft.net*
+* **Website**: *[ritcraft.net](https://ritcraft.net)*
 
 
 ## What should it have?
 This website only needs a few basic things, as detailed below:
 
-* Introduction ("What is RITCraft?")
+* Introduction ("What is RITcraft?")
 * Server Information (where and how to join)
 * Server Plans (even a manual, editable bullet list would be fine)
 * How to Help (link to this repo, plus plug for Telegram group)
@@ -21,7 +21,7 @@ More might be added or expanded to this over time.
 
 
 ## I want to help!
-Want to help with either this website or RITCraft? Awesome! Feel free to submit pull requests to this repo if you want to help with the website, or if you want to help with the server, join our Telegram group chat. To prevent the spam bots from finding us, we won't link the invite URL here, but the link is constantly cycled through the server in-game - look for it there!
+Want to help with either this website or RITcraft? Awesome! Feel free to submit pull requests to this repo if you want to help with the website. If you want to help with the server, join our [Slack team](https://ritcraft.slack.com/signup). You will have to have an RIT email to join by yourself. If you do not have an RIT email address and wish to be added, please contact Justin (jflory7).
 
 
 ## Website Info

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -44,10 +44,10 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
                 <li>
-                    <a href="http://rit.j-f.co:8123/" target="_blank">DynMap</a>
+                    <a href="http://mc.ritcraft.net:8123/" target="_blank">DynMap</a>
                 </li>
                 <li>
-                    <a href="http://rit.j-f.co:3333/" target="_blank">Trading Post</a>
+                    <a href="http://mc.ritcraft.net:3333/" target="_blank">Trading Post</a>
                 </li>
                 <li>
                     <a href=".">Events Calendar</a>
@@ -64,7 +64,7 @@
     <footer>
         <div class="row">
             <div class="col-lg-12">
-                <p align="center">Copyright &copy; RITcraft 2015. View this project on <a href="https://github.com/RITcraft/RITcraft-Site" target="_blank">GitHub</a>.</p>
+                <p align="center">Copyright &copy; RITcraft 2015-2016. View this project on <a href="https://github.com/RITcraft/ritcraft.net" target="_blank">GitHub</a>.</p>
             </div>
         </div>
     </footer>

--- a/index.php
+++ b/index.php
@@ -44,10 +44,10 @@
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav">
                     <li>
-                        <a href="http://rit.j-f.co:8123/" target="_blank">DynMap</a>
+                        <a href="http://mc.ritcraft.net:8123/" target="_blank">DynMap</a>
                     </li>
                     <li>
-                        <a href="http://rit.j-f.co:3333/" target="_blank">Trading Post</a>
+                        <a href="http://mc.ritcraft.net:3333/" target="_blank">Trading Post</a>
                     </li>
                     <li>
                         <a href="calendar/">Events Calendar</a>
@@ -122,7 +122,7 @@
         <footer>
             <div class="row">
                 <div class="col-lg-12">
-                    <p>Copyright &copy; RITcraft 2015-2016. View this project on <a href="https://github.com/RITcraft/RITcraft-Site" target="_blank">GitHub</a>.</p>
+                    <p>Copyright &copy; RITcraft 2015-2016. View this project on <a href="https://github.com/RITcraft/ritcraft.net" target="_blank">GitHub</a>.</p>
                 </div>
             </div>
         </footer>

--- a/index.php
+++ b/index.php
@@ -20,9 +20,21 @@
     <link href="css/portfolio-item.css" rel="stylesheet">
 
 <?php
-    include_once 'status.class.php'; // Include the server status monitor script
-    $status = new MinecraftServerStatus();
-?>
+use MinecraftServerStatus\MinecraftServerStatus;
+
+require '../vendor/autoload.php';
+
+$response = MinecraftServerStatus::query('mc.ritcraft.net', 30000);
+
+if (! $response) {
+    echo "RITcraft is offline!";
+} else {
+    echo "<img width=\"64\" height=\"64\" src=\"" . $response['favicon'] . "\" /> <br>
+		RITcraft " . $response['hostname'] . " is running on " . $response['version'] . " and is online,
+		currently are " . $response['players'] . " players online
+		of a maximum of " . $response['max_players'] . ". The motd of the server is '" . $response['description'] . "'.
+		The server has a ping of " . $response['ping'] . " milliseconds.";
+} ?>
 
 </head>
 

--- a/status.class.php
+++ b/status.class.php
@@ -14,7 +14,7 @@
             $this->timeout = $timeout;
         }
 
-        public function getStatus($host = '127.0.0.1', $port = 25565, $version = '1.7.*') {
+        public function getStatus($host = 'mc.ritcraft.net', $port = 30000, $version = '1.8.*') {
 
             if (substr_count($host , '.') != 4) $host = gethostbyname($host);
 

--- a/status.class.php
+++ b/status.class.php
@@ -1,169 +1,95 @@
 <?php
+/**
+ * Minecraft Server Status Query
+ *
+ * @link        https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/
+ * @author      Julian Spravil <julian.spr@t-online.de>
+ * @copyright   Copyright (c) 2016 Julian Spravil
+ * @license     https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query/blob/master/LICENSE
+ */
+namespace MinecraftServerStatus;
+use MinecraftServerStatus\Packets\HandshakePacket;
+use MinecraftServerStatus\Packets\PingPacket;
+
+class MinecraftServerStatus {
 
     /**
-     * Minecraft Server Status Query
-     * @author Julian Spravil <julian.spr@t-online.de> https://github.com/FunnyItsElmo
-     * @license Free to use but dont remove the author, license and copyright
-     * @copyright © 2013 Julian Spravil
+     * Queries the server and returns the servers information
+     *
+     * @param string $host            
+     * @param number $port            
      */
-    class MinecraftServerStatus {
-
-        private $timeout;
-
-        public function __construct($timeout = 2) {
-            $this->timeout = $timeout;
+    public static function query ($host = '127.0.0.1', $port = 25565) {
+        // check if the host is in ipv4 format
+        $host = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
+        
+        $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if (! @socket_connect($socket, $host, $port)) {
+            return false;
         }
+        
+        // create the handshake and ping packet
+        $handshakePacket = new HandshakePacket($host, $port, 107, 1);
+        $pingPacket = new PingPacket();
+        
+        $handshakePacket->send($socket);
+        
+        // high five
+        $start = microtime(true);
+        $pingPacket->send($socket);
+        $length = self::readVarInt($socket);
+        $ping = round((microtime(true) - $start) * 1000);
+        
+        // read the requested data
+        $data = socket_read($socket, $length, PHP_NORMAL_READ);
+        $data = strstr($data, '{');
+        $data = json_decode($data);
+        
+        $descriptionRaw = isset($data->description) ? $data->description : false;
+        $description = $descriptionRaw;
+        
+        // colorize the description if it is supported
+        if (gettype($descriptionRaw) == 'object' && isset($descriptionRaw->extra)) {
+            $description = '';
+            foreach ($descriptionRaw->extra as $item) {
+                $description .= isset($item->bold) && $item->bold ? '<b>' : '';
+                $description .= '<font color="' . $item->color . '">' . $item->text . '</font>';
+                $description .= isset($item->bold) && $item->bold ? '</b>' : '';
+            }
+        }
+        
+        return array(
+                'hostname' => $host,
+                'port' => $port,
+                'ping' => $ping,
+                'version' => isset($data->version->name) ? $data->version->name : false,
+                'protocol' => isset($data->version->protocol) ? $data->version->protocol : false,
+                'players' => isset($data->players->online) ? $data->players->online : false,
+                'max_players' => isset($data->players->max) ? $data->players->max : false,
+                'description' => $description,
+                'description_raw' => $descriptionRaw,
+                'favicon' => isset($data->favicon) ? $data->favicon : false,
+                'modinfo' => isset($data->modinfo) ? $data->modinfo : false
+        );
+    }
 
-        public function getStatus($host = 'mc.ritcraft.net', $port = 30000, $version = '1.8.*') {
-
-            if (substr_count($host , '.') != 4) $host = gethostbyname($host);
-
-            $serverdata = array();
-            $serverdata['hostname'] = $host;
-            $serverdata['version'] = false;
-            $serverdata['protocol'] = false;
-            $serverdata['players'] = false;
-            $serverdata['maxplayers'] = false;
-            $serverdata['motd'] = false;
-            $serverdata['motd_raw'] = false;
-            $serverdata['favicon'] = false;
-            $serverdata['ping'] = false;
-
-            $socket = $this->connect($host, $port);
-
-            if(!$socket) {
+    private static function readVarInt ($socket) {
+        $a = 0;
+        $b = 0;
+        while (true) {
+            $c = socket_read($socket, 1);
+            if (! $c) {
+                return 0;
+            }
+            $c = Ord($c);
+            $a |= ($c & 0x7F) << $b ++ * 7;
+            if ($b > 5) {
                 return false;
             }
-
-            if(preg_match('/1.7|1.8/',$version)) {
-
-                $start = microtime(true);
-
-                $handshake = pack('cccca*', hexdec(strlen($host)), 0, 0x04, strlen($host), $host).pack('nc', $port, 0x01);
-
-                socket_send($socket, $handshake, strlen($handshake), 0); //give the server a high five
-                socket_send($socket, "\x01\x00", 2, 0);
-                socket_read( $socket, 1 );
-
-                $ping = round((microtime(true)-$start)*1000); //calculate the high five duration
-
-                $packetlength = $this->read_packet_length($socket);
-
-                if($packetlength < 10) {
-                    return false;
-                }
-
-                socket_read($socket, 1);
-
-                $packetlength = $this->read_packet_length($socket);
-
-                $data = socket_read($socket, $packetlength, PHP_NORMAL_READ);
-
-                if(!$data) {
-                    return false;
-                }
-
-                $data = json_decode($data);
-
-                $serverdata['version'] = $data->version->name;
-                $serverdata['protocol'] = $data->version->protocol;
-                $serverdata['players'] = $data->players->online;
-                $serverdata['maxplayers'] = $data->players->max;
-
-                $motd = $data->description;
-                $motd = preg_replace("/(§.)/", "",$motd);
-                $motd = preg_replace("/[^[:alnum:][:punct:] ]/", "", $motd);
-
-                $serverdata['motd'] = $motd;
-                $serverdata['motd_raw'] = $data->description;
-                $serverdata['favicon'] = $data->favicon;
-                $serverdata['ping'] = $ping;
-
-            } else {
-
-                $start = microtime(true);
-
-                socket_send($socket, "\xFE\x01", 2, 0);
-                $length = socket_recv($socket, $data, 512, 0);
-
-                $ping = round((microtime(true)-$start)*1000);//calculate the high five duration
-
-                if($length < 4 || $data[0] != "\xFF") {
-                    return false;
-                }
-
-                $motd = "";
-                $motdraw = "";
-
-                //Evaluate the received data
-                if (substr((String)$data, 3, 5) == "\x00\xa7\x00\x31\x00"){
-
-                    $result = explode("\x00", mb_convert_encoding(substr((String)$data, 15), 'UTF-8', 'UCS-2'));
-                    $motd = $result[1];
-                    $motdraw = $motd;
-
-                } else {
-
-                    $result = explode('§', mb_convert_encoding(substr((String)$data, 3), 'UTF-8', 'UCS-2'));
-                        foreach ($result as $key => $string) {
-                            if($key != sizeof($result)-1 && $key != sizeof($result)-2 && $key != 0) {
-                                $motd .= '§'.$string;
-                            }
-                        }
-                        $motdraw = $motd;
-                    }
-
-                    $motd = preg_replace("/(§.)/", "", $motd);
-                    $motd = preg_replace("/[^[:alnum:][:punct:] ]/", "", $motd); //Remove all special characters from a string
-
-                    $serverdata['version'] = $result[0];
-                    $serverdata['players'] = $result[sizeof($result)-2];
-                    $serverdata['maxplayers'] = $result[sizeof($result)-1];
-                    $serverdata['motd'] = $motd;
-                    $serverdata['motd_raw'] = $motdraw;
-                    $serverdata['ping'] = $ping;
-
-            }
-
-            $this->disconnect($socket);
-
-            return $serverdata;
-
-        }
-
-        private function connect($host, $port) {
-            $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-            if (!@socket_connect($socket, $host, $port)) {
-        		$this->disconnect($socket);
-        		return false;
-    	    }
-            return $socket;
-        }
-
-        private function disconnect($socket) {
-            if($socket != null) {
-                socket_close($socket);
+            if (($c & 0x80) != 128) {
+                break;
             }
         }
-
-        private function read_packet_length($socket) {
-            $a = 0;
-            $b = 0;
-            while(true) {
-                $c = socket_read($socket, 1);
-                if(!$c) {
-                    return 0;
-                }
-                $c = Ord($c);
-                $a |= ($c & 0x7F) << $b++ * 7;
-                if( $b > 5 ) {
-                    return false;
-                }
-                if(($c & 0x80) != 128) {
-                    break;
-                }
-            }
-            return $a;
-        }
-
+        return $a;
     }
+}

--- a/update_from_git.sh
+++ b/update_from_git.sh
@@ -12,7 +12,7 @@
 #    painless and simple as possible
 #
 
-WEBDIR=/var/www/rit.j-f.co/public_html
+WEBDIR=/var/www/ritcraft.net/public_html
 
 #####################################################
 # Pull down the latest changes from GitHub          #


### PR DESCRIPTION
This pull request adds the latest upstream version of the [PHP-Minecraft-Server-Status-Query](https://github.com/FunnyItsElmo/PHP-Minecraft-Server-Status-Query) script from @FunnyItsElmo. Ideally, if implemented correctly, it should ping the server and have the status display on the site.

I haven't had a chance to test this in a staging or production instance.

@repkam09, think you could take a look at this PR and give some feedback? You're a little more PHP savvy than I am.
